### PR TITLE
add inputSearchHideable and inputSearchWidth vis params

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+npm-debug.log*
+node_modules
+/build/

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kbn_searchtables",
-  "version": "5.5.0-1",
+  "version": "5.5.0-4",
   "kibana": {
     "version": "5.5.0"
   },

--- a/public/kbn_searchtables.html
+++ b/public/kbn_searchtables.html
@@ -7,18 +7,18 @@
 
   <div ng-if="tableGroups" class="kbn-searchtables-container">
 
-    <div ng-hide="showInput" class="width: 100%;" align="right">
+    <div ng-hide="showInput || !vis.params.inputSearchHideable" class="width: 100%;" align="right">
       <a ng-click="showInput = true" class="textSearch">Search</a>
     </div>
 
-  	<div class="kuiLocalSearch"  class="inputSearchContainer" ng-show="showInput">
+  	<div class="kuiLocalSearch" class="inputSearchContainer" ng-show="showInput || !vis.params.inputSearchHideable" style="width:{{vis.params.inputSearchWidth}}">
       <div class="kuiLocalSearchAssistedInput" style="width:100%">
         <input ng-model="inputSearch" ng-keyup="$event.keyCode == 13 && doSearch($id)" id="inputSearch_{{$id}}" placeholder="Search..." class="kuiLocalSearchInput ng-touched inputSearch" autocomplete="off" type="text">
       </div>
       <button ng-click="doSearch($id)" aria-label="Search" class="kuiLocalSearchButton inputSearchButton">
         <span aria-hidden="true" class="kuiIcon fa-search"></span>
       </button>
-      <button ng-click="showInput = false" class="kuiLocalSearchButton cancelSearchButton">
+      <button ng-click="showInput = false" ng-show="vis.params.inputSearchHideable" class="kuiLocalSearchButton cancelSearchButton">
         <span aria-hidden="true" class="kuiIcon kuiButton--danger fa-times"></span>
       </button>
     </div>

--- a/public/kbn_searchtables.js
+++ b/public/kbn_searchtables.js
@@ -49,7 +49,9 @@ function SearchTablesVisTypeProvider(Private) {
         },
         showTotal: false,
         totalFunc: 'sum',
-        caseSensitive: true
+        caseSensitive: true,
+        inputSearchHideable: true,
+        inputSearchWidth: '100%'
       },
       editor: '<search-tables-vis-params></search-tables-vis-params>'
     },

--- a/public/kbn_searchtables_params.html
+++ b/public/kbn_searchtables_params.html
@@ -38,6 +38,18 @@
   </label>
 </div>
 
+<div class="checkbox">
+  <label>
+    <input type="checkbox" ng-model="vis.params.inputSearchHideable">
+    Input Search Hideable
+  </label>
+</div>
+
+<div class="form-group">
+  <label>Input Search Width</label>
+  <input type="text" ng-model="vis.params.inputSearchWidth" class="form-control">
+</div>
+
 <div>
   <label>Total function</label>
   <select ng-disabled="!vis.params.showTotal"


### PR DESCRIPTION
This PR brings 2 new features : 
- inputSearchHideable : a new vis param, that allow (when unchecked) to always show input search
- inputSearchWidth : a new vis param, that allow to custom input search width (100% by default)
